### PR TITLE
comparing uppercase/lowercase hashes

### DIFF
--- a/BitSwarm/BEP/Torrent.cs
+++ b/BitSwarm/BEP/Torrent.cs
@@ -358,7 +358,7 @@ namespace SuRGeoNix.BitSwarmLib.BEP
                 metadata.file.Dispose();
                 BDictionary bInfo   = (BDictionary) bParser.Parse(curFilePath);
 
-                if (file.infoHash != Utils.ArrayToStringHex(sha1.ComputeHash(bInfo.EncodeAsBytes())))
+                if (file.infoHash.ToLowerInvariant() != Utils.ArrayToStringHex(sha1.ComputeHash(bInfo.EncodeAsBytes())).ToLowerInvariant())
                     bitSwarm.StopWithError("[CRITICAL] Metadata SHA1 validation failed");
 
                 file.name = ((BString) bInfo["name"]).ToString();


### PR DESCRIPTION
Hashes can be uppercase and lowercase, this lead to crashes, as it compared identical hashes as not equal.

with this fix, magnet links with lower case hashes work.